### PR TITLE
strong params for address nested attributes

### DIFF
--- a/app/controllers/reg_forms_controller.rb
+++ b/app/controllers/reg_forms_controller.rb
@@ -23,6 +23,6 @@ class RegFormsController < ApplicationController
 
   private
   def reg_form_params
-    params.require(:reg_form).permit(:name, :email, :phone, :user_id, :address)
+    params.require(:reg_form).permit(:name, :email, :phone, :user_id, address_attributes: [:line1, :line2, :city, :state, :zip])
   end
 end


### PR DESCRIPTION
address is its own table and polymorphic for consistent use across any other forms and can be queried alone

as part of a reg form, example usage:

example = RegForm.last
example.address.city
example.address.line1

whereas direct attributes are as normal: example.name, example.phone, &c
